### PR TITLE
1.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/flit_scm-{{ version }}.tar.gz
-  sha256: 4255d59898416891010144c96b1fe53274262224e285afbc6426c1f5024a9b1e
+  sha256: 15d9ea75cf74ddbeea85ac112482e2b020969bb41180d2b19d8301a24220cad3
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,4 +49,3 @@ extra:
   recipe-maintainers:
     - xylar
     - WillDaSilva
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "flit-scm" %}
-{% set version = "1.4.1" %}
+{% set version = "1.6.1" %}
 
 package:
   name: {{ name|lower }}
@@ -17,15 +17,15 @@ build:
 requirements:
   host:
     - python >=3.6
-    - flit-core 3.5.0
+    - flit-core >=3.5.0,<4
     - pip
-    - setuptools_scm 6.4.2
-    - toml 0.10.2
+    - setuptools_scm >=6.4.2,<7
+    - tomli
   run:
     - python >=3.6
-    - flit-core 3.5.0
-    - setuptools_scm 6.4.2
-    - toml 0.10.2
+    - flit-core >=3.5.0,<4
+    - setuptools_scm >=6.4.2,<7
+    - tomli
 test:
   imports:
     - flit_scm
@@ -48,3 +48,5 @@ about:
 extra:
   recipe-maintainers:
     - xylar
+    - WillDaSilva
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/flit_scm-{{ version }}.tar.gz
-  sha256: fd0c704375b4424152caced0584cebe4131ccdc236a239dd1a055a80ee935f70
+  sha256: 4255d59898416891010144c96b1fe53274262224e285afbc6426c1f5024a9b1e
 
 build:
   noarch: python
@@ -49,3 +49,4 @@ extra:
   recipe-maintainers:
     - xylar
     - WillDaSilva
+


### PR DESCRIPTION
- Replaced `toml` with `tomli`.
- Updated requirement version constraints to match `flit_scm`.